### PR TITLE
Fix output of usage() function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ usage(){
     echo
     echo "  -s SOURCE_TYPE : How to configure the Hostname field in collectd.conf:"
     echo "                    aws - use the aws instance id."
-    echo "                    hostname - set a hostname. See --hostname"
+    echo "                    input - set a hostname. See --hostname"
     echo "                    dns - use FQDN of the host as the Hostname"
     echo
     echo " -H HOSTNAME: The Hostname value to use if you selected hostname as your source_type"


### PR DESCRIPTION
The usage instructions stated that `hostname` is a valid value passed to
the `-s` flag for `SOURCE_TYPE`. This should in fact be `input`
according to the `$SOURCE_TYPE` case statement.