### PR TITLE
Remove aws as an option for hostname configuration

### DIFF
--- a/managed_config/10-write_http-plugin.conf
+++ b/managed_config/10-write_http-plugin.conf
@@ -1,6 +1,6 @@
 LoadPlugin write_http
 <Plugin "write_http">
-  <URL "%%%INGEST_HOST%%%/v1/collectd">
+  <URL "%%%INGEST_HOST%%%/v1/collectd%%%EXTRA_DIMS%%%">
     User "auth"
     Password "%%%API_TOKEN%%%"
     Format "JSON"


### PR DESCRIPTION
- Detection of the script running on an AWS instance in now
automatic.
- Instead of using the Host field in collectd.conf, use
sfxdim_InstanceId cgi param on the ingest URL in the write_http
plugin configuration to send InstanceId for aws tag syncing

Also fixed some whitespace issues