### PR TITLE
cassandra: rename metrics to match Cassandra JMX metric names

### DIFF
--- a/managed_config/20-cassandra.conf
+++ b/managed_config/20-cassandra.conf
@@ -22,22 +22,22 @@
       ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-client-read-latency-median"
+        InstancePrefix "cassandra.ClientRequest.Read.Latency.50thPercentile"
         Attribute "50thPercentile"
       </Value>
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-client-read-latency-max"
+        InstancePrefix "cassandra.ClientRequest.Read.Latency.Max"
         Attribute "Max"
       </Value>
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-client-read-latency-99th"
+        InstancePrefix "cassandra.ClientRequest.Read.Latency.99thPercentile"
         Attribute "99thPercentile"
       </Value>
       <Value>
         Type "counter"
-        InstancePrefix "cassandra-client-read-latency-count"
+        InstancePrefix "cassandra.ClientRequest.Read.Latency.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -46,7 +46,7 @@
       ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Timeouts"
       <Value>
         Type "counter"
-        InstancePrefix "cassandra-client-read-timeouts"
+        InstancePrefix "cassandra.ClientRequest.Read.Timeouts.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -55,7 +55,7 @@
       ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Unavailables"
       <Value>
         Type "counter"
-        InstancePrefix "cassandra-client-read-unavailables"
+        InstancePrefix "cassandra.ClientRequest.Read.Unavailables.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -64,22 +64,22 @@
       ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=RangeSlice,name=Latency"
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-client-rangeslice-latency-median"
+        InstancePrefix "cassandra.ClientRequest.RangeSlice.Latency.50thPercentile"
         Attribute "50thPercentile"
       </Value>
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-client-rangeslice-latency-max"
+        InstancePrefix "cassandra.ClientRequest.RangeSlice.Latency.Max"
         Attribute "Max"
       </Value>
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-client-rangeslice-latency-99th"
+        InstancePrefix "cassandra.ClientRequest.RangeSlice.Latency.99thPercentile"
         Attribute "99thPercentile"
       </Value>
       <Value>
         Type "counter"
-        InstancePrefix "cassandra-client-rangeslice-latency-count"
+        InstancePrefix "cassandra.ClientRequest.RangeSlice.Latency.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -88,7 +88,7 @@
       ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=RangeSlice,name=Timeouts"
       <Value>
         Type "counter"
-        InstancePrefix "cassandra-client-rangeslice-timeouts"
+        InstancePrefix "cassandra.ClientRequest.RangeSlice.Timeouts.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -97,7 +97,7 @@
       ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=RangeSlice,name=Unavailables"
       <Value>
         Type "counter"
-        InstancePrefix "cassandra-client-rangeslice-unavailables"
+        InstancePrefix "cassandra.ClientRequest.RangeSlice.Unavailables.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -106,22 +106,22 @@
       ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-client-write-latency-median"
+        InstancePrefix "cassandra.ClientRequest.Write.Latency.50thPercentile"
         Attribute "50thPercentile"
       </Value>
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-client-write-latency-max"
+        InstancePrefix "cassandra.ClientRequest.Write.Latency.Max"
         Attribute "Max"
       </Value>
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-client-write-latency-99th"
+        InstancePrefix "cassandra.ClientRequest.Write.Latency.99thPercentile"
         Attribute "99thPercentile"
       </Value>
       <Value>
         Type "counter"
-        InstancePrefix "cassandra-client-write-latency-count"
+        InstancePrefix "cassandra.ClientRequest.Write.Latency.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -130,7 +130,7 @@
       ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Timeouts"
       <Value>
         Type "counter"
-        InstancePrefix "cassandra-client-write-timeouts"
+        InstancePrefix "cassandra.ClientRequest.Write.Timeouts.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -139,7 +139,7 @@
       ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Unavailables"
       <Value>
         Type "counter"
-        InstancePrefix "cassandra-client-write-unavailables"
+        InstancePrefix "cassandra.ClientRequest.Write.Unavailables.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -148,7 +148,7 @@
       ObjectName "org.apache.cassandra.metrics:type=Storage,name=Load"
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-storage-load"
+        InstancePrefix "cassandra.Storage.Load.Count"
         Attribute "Count"
       </Value>
     </MBean>
@@ -157,8 +157,17 @@
       ObjectName "org.apache.cassandra.metrics:type=Compaction,name=PendingTasks"
       <Value>
         Type "gauge"
-        InstancePrefix "cassandra-compaction-pending-tasks"
+        InstancePrefix "cassandra.Compaction.PendingTasks.Value"
         Attribute "Value"
+      </Value>
+    </MBean>
+
+    <MBean "cassandra-compaction-total-completed">
+      ObjectName "org.apache.cassandra.metrics:type=Compaction,name=TotalCompactionsCompleted"
+      <Value>
+        Type "counter"
+        InstancePrefix "cassandra.Compaction.TotalCompactionsCompleted.Count"
+        Attribute "Count"
       </Value>
     </MBean>
 
@@ -185,6 +194,7 @@
 
       Collect "cassandra-storage"
       Collect "cassandra-compaction-pending-tasks"
+      Collect "cassandra-compaction-total-completed"
     </Connection>
   </Plugin>
 </Plugin>


### PR DESCRIPTION
because there’s no good reason for them to be different.

Also added total compactions metric