### PR TITLE
RabbitMQ: Add HTTPTimeout setting and remove Realm

### DIFF
--- a/managed_config/10-rabbitmq.conf
+++ b/managed_config/10-rabbitmq.conf
@@ -15,10 +15,12 @@
 #   None
 #
 # Config file modifications:
-#   Change the Username, Password, Realm, Host, and Port settings to match
-#   your RabbitMQ installation.
+#   Change the Username, Password, Host, and Port settings to match your
+#   RabbitMQ installation.
 #   Optionally, change any of the Collect* settings to false to disable
 #   their collection.
+#   The optional setting HTTPTimeout will set a timeout value (in seconds) for
+#   connecting to the RabbitMQ Management API. Defaults to 1 second.
 
 LoadPlugin python
 <Plugin python>
@@ -28,7 +30,6 @@ LoadPlugin python
   <Module rabbitmq>
     Username "guest"
     Password "guest"
-    Realm "RabbitMQ Management"
     Host "localhost"
     Port "15672"
     CollectChannels true
@@ -36,5 +37,6 @@ LoadPlugin python
     CollectExchanges true
     CollectNodes true
     CollectQueues true
+    # HTTPTimeout 1
   </Module>
 </Plugin>


### PR DESCRIPTION
Modifies the example RabbitMQ configuration file to reflect recent
changes in the plugin.