### PR TITLE
Set ReportUtilizedState to true so cpu-plug in will generate cpu.utilization by default

### DIFF
--- a/collectd.conf
+++ b/collectd.conf
@@ -49,6 +49,11 @@ LoadPlugin logfile
 </Plugin>
 
 LoadPlugin cpu
+
+<Plugin "cpu">
+  ReportUtilizedState true
+</Plugin>
+
 LoadPlugin cpufreq
 LoadPlugin df
 


### PR DESCRIPTION
In support of https://signalfuse.atlassian.net/browse/FUSE-7278 I added cpu plug-in configuration information to collectd.conf to make the CPU plug-in generate the new "cpu.utilized" metric by default when SignalFX's collectd configuration is used