### PR TITLE
Update names and log level in Mesos configs

### DIFF
--- a/managed_config/10-mesos-master.conf
+++ b/managed_config/10-mesos-master.conf
@@ -27,10 +27,11 @@
   Import "mesos-master"
 
   <Module "mesos-master">
-    Instance "mesos-master"
+    Cluster "cluster-0"
+    Instance "master-0"
     Host "%%%MASTER_IP%%%"
     Port %%%MASTER_PORT%%%
-    Verbose true
+    Verbose false
     Version "%%%VERSION_MESOS%%%"
   </Module>
 </Plugin>

--- a/managed_config/10-mesos-slave.conf
+++ b/managed_config/10-mesos-slave.conf
@@ -13,8 +13,8 @@
 #   None
 #
 # Config file modifications:
-#   Replace %%%AGENT_IP%%% with the IP address or hostname of the agent,
-#   %%%AGENT_PORT%%% with the port on which the agent is listening, and
+#   Replace %%%SLAVE_IP%%% with the IP address or hostname of the slave,
+#   %%%SLAVE_PORT%%% with the port on which the slave is listening, and
 #   %%%VERSION_MESOS%%% with the version of Mesos being run.
 
 <LoadPlugin "python">
@@ -27,10 +27,19 @@
   Import "mesos-slave"
 
   <Module "mesos-slave">
-    Instance "mesos-agent"
-    Host "%%%AGENT_IP%%%"
-    Port %%%AGENT_PORT%%%
-    Verbose true
+    Cluster "cluster-0"
+    Instance "slave-0"
+    Host "%%%SLAVE_IP%%%"
+    Port %%%SLAVE_0_PORT%%%
+    Verbose false
+    Version "%%%VERSION_MESOS%%%"
+  </Module>
+  <Module "mesos-slave">
+    Cluster "cluster-0"
+    Instance "slave-1"
+    Host "%%%SLAVE_IP%%%"
+    Port %%%SLAVE_1_PORT%%%
+    Verbose false
     Version "%%%VERSION_MESOS%%%"
   </Module>
 </Plugin>


### PR DESCRIPTION
Rename "agent" to "slave", to be consistent with Mesos terminology.
Add cluster name. Turn off logging verbosity. Add a second slave.