### PR TITLE
Add verbosity level to RabbitMQ config

### DIFF
--- a/managed_config/10-rabbitmq.conf
+++ b/managed_config/10-rabbitmq.conf
@@ -19,8 +19,16 @@
 #   RabbitMQ installation.
 #   Optionally, change any of the Collect* settings to false to disable
 #   their collection.
+#
 #   The optional setting HTTPTimeout will set a timeout value (in seconds) for
-#   connecting to the RabbitMQ Management API. Defaults to 1 second.
+#   connecting to the RabbitMQ Management API. Defaults to 60 seconds.
+#
+#   The optional setting VerbosityLevel controls the quantity of RabbitMQ
+#   metrics collected.
+#       "info": Only the most commonly-used metrics are collected
+#       "debug": Additonal metrics useful for debugging are collected
+#       "trace": All available metrics are collected
+#   Defaults to "info".
 
 LoadPlugin python
 <Plugin python>
@@ -37,6 +45,7 @@ LoadPlugin python
     CollectExchanges true
     CollectNodes true
     CollectQueues true
-    # HTTPTimeout 1
+    # HTTPTimeout 60
+    # VerbosityLevel "info"
   </Module>
 </Plugin>


### PR DESCRIPTION
Adds an example for the new VerbosityLevel config setting for the
RabbitMQ plugin. Also updates the HTTP default timeout that was
previously changed.