### PR TITLE
Remove Version setting from Mesos configs

### DIFF
--- a/managed_config/10-mesos-master.conf
+++ b/managed_config/10-mesos-master.conf
@@ -13,9 +13,8 @@
 #   None
 #
 # Config file modifications:
-#   Replace %%%MASTER_IP%%% with the IP address or hostname of the master,
-#   %%%MASTER_PORT%%% with the port on which the master is listening, and
-#   %%%VERSION_MESOS%%% with the version of Mesos being run.
+#   Replace %%%MASTER_IP%%% with the IP address or hostname of the master
+#   and %%%MASTER_PORT%%% with the port on which the master is listening.
 
 <LoadPlugin "python">
   Globals true
@@ -32,6 +31,5 @@
     Host "%%%MASTER_IP%%%"
     Port %%%MASTER_PORT%%%
     Verbose false
-    Version "%%%VERSION_MESOS%%%"
   </Module>
 </Plugin>

--- a/managed_config/10-mesos-slave.conf
+++ b/managed_config/10-mesos-slave.conf
@@ -13,9 +13,8 @@
 #   None
 #
 # Config file modifications:
-#   Replace %%%SLAVE_IP%%% with the IP address or hostname of the slave,
-#   %%%SLAVE_PORT%%% with the port on which the slave is listening, and
-#   %%%VERSION_MESOS%%% with the version of Mesos being run.
+#   Replace %%%SLAVE_IP%%% with the IP address or hostname of the slave
+#   and %%%SLAVE_PORT%%% with the port on which the slave is listening.
 
 <LoadPlugin "python">
   Globals true
@@ -32,7 +31,6 @@
     Host "%%%SLAVE_IP%%%"
     Port %%%SLAVE_0_PORT%%%
     Verbose false
-    Version "%%%VERSION_MESOS%%%"
   </Module>
   <Module "mesos-slave">
     Cluster "cluster-0"
@@ -40,6 +38,5 @@
     Host "%%%SLAVE_IP%%%"
     Port %%%SLAVE_1_PORT%%%
     Verbose false
-    Version "%%%VERSION_MESOS%%%"
   </Module>
 </Plugin>


### PR DESCRIPTION
The signalfx/collectd-mesos plugin now gets the version number from
the running Mesos.