### PR TITLE
Adding a command line argument to be able to pass ingest_url

### DIFF
--- a/collectd-package-install
+++ b/collectd-package-install
@@ -13,11 +13,13 @@ source_type=""
 name=collectd_package_install
 debian_distribution_name=""
 local=0
+sfx_ingest_url="https://ingest.signalfx.com"
 
 usage() {
-    echo "Usage: $name [ <api_token> ] [ --beta | --test ] [ -H <hostname> ] [ -h ] [ -y ]"
+    echo "Usage: $name [ <api_token> ] [ --beta | --test ] [ -H <hostname> ] [ -U <Ingest URL>] [ -h ] [ -y ]"
     echo " -y makes the operation non-interactive. api_token is required and defaults to dns if no hostname is set"
     echo " -H <hostname> will set the collectd hostname to <hostname> instead of what dns says."
+    echo " -U <Ingest URL> will be used as the ingest url. Defaults to ${sfx_ingest_url}"
     echo " --beta will use the beta repos instead of release."
     echo " --test will use the test repos instead of release."
     echo " -h this page."
@@ -41,6 +43,9 @@ parse_args(){
            -H)
               [ -z "$2" ] && echo "Argument required for hostname parameter." && usage -1
               source_type="-s input -H $2"; shift 2 ;;
+           -U)
+              [ -z "$2" ] && echo "Argument required for Ingest URL parameter." && usage -1
+              sfx_ingest_url="$2"; shift 2 ;;
            -h)
                usage 0; ;;
            \?) echo "Invalid option: -$1" >&2;
@@ -74,7 +79,7 @@ if [ $interactive -eq 0 ] && [ -z "$api_token" ]; then
 fi
 
 if [ -n "$api_token" ]; then
-    api_output=`curl -d '[]' -H "X-Sf-Token: $raw_api_token" -H "Content-Type:application/json" -X POST https://ingest.signalfx.com/v2/event 2>/dev/null`
+    api_output=`curl -d '[]' -H "X-Sf-Token: $raw_api_token" -H "Content-Type:application/json" -X POST $sfx_ingest_url/v2/event 2>/dev/null`
     if [ ! "$api_output" = "\"OK\"" ]; then
         echo "There was a problem with the api token '$raw_api_token' passed in and we were unable to communicate with SignalFx: $api_output"
         echo "Please check your auth token is valid or check your networking."
@@ -116,7 +121,7 @@ fi
 #Functions used throughout
 basic_collectd()
 {
-   options=" ${source_type} ${installer_level} ${api_token}"
+   options=" ${source_type} ${installer_level} ${api_token} -i ${sfx_ingest_url}"
    printf "Starting Configuration of collectd... $options \n"
 
    if [ $local -eq 1 ]; then
@@ -163,7 +168,7 @@ assign_needed_os()
         8)
             hostOS="Ubuntu 12.04"
         ;;
-        #Debian GNU/Linux 7 (wheezy) 
+        #Debian GNU/Linux 7 (wheezy)
         9)
             hostOS="Debian GNU/Linux 7"
         ;;
@@ -215,7 +220,7 @@ Please enter the number of the OS you wish to install for:
 8. Ubuntu 12.04
 9. Debian GNU/Linux 7
 10. Debian GNU/Linux 8
-11. Other 
+11. Other
 0. Exit
 Enter your Selection: "
 	read -r selection < /dev/tty

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd 2>/dev/null)
 source "${SCRIPT_DIR}/install_helpers"
+SFX_INGEST_URL="https://ingest.signalfx.com"
 
 get_logfile() {
     LOGTO="\"/var/log/signalfx-collectd.log\""
@@ -87,7 +88,7 @@ get_source_config() {
 
 usage(){
     echo "$0 [-s SOURCE_TYPE] [-t API_TOKEN] [-u SIGNALFX_USER]"
-    echo "   [-o SIGNALFX_ORG] [-H HOSTNAME] [/path/to/collectd]"
+    echo "   [-o SIGNALFX_ORG] [-H HOSTNAME] [-i SFX_INGEST_URL] [/path/to/collectd]"
     echo "Installs collectd.conf and configures it for talking to SignalFx."
     echo "Installs the SignalFx collectd plugin on supported oses.  If on an unknown os"
     echo "and the plugin is already present, will configure it."
@@ -98,6 +99,8 @@ usage(){
     echo "                    dns - use FQDN of the host as the Hostname"
     echo
     echo " -H HOSTNAME: The Hostname value to use if you selected hostname as your source_type"
+    echo
+    echo " -i SFX_INGEST_URL: The Ingest URL to be used. Defaults to ${SFX_INGEST_URL}"
     echo
     echo "  Configuring SignalFX access"
     echo "------------------------------"
@@ -110,7 +113,6 @@ usage(){
 }
 
 parse_args(){
-    SFX_INGEST_URL="https://ingest.signalfx.com"
     release_type=release
     while getopts ":s:t:u:o:H:hbTa:i:" opt; do
         case "$opt" in
@@ -221,7 +223,7 @@ install_signalfx_plugin() {
 }
 
 install_write_http_plugin(){
-    install_plugin_common 
+    install_plugin_common
 
     printf "Fixing write_http plugin configuration.."
     sed -e "s#%%%API_TOKEN%%%#${API_TOKEN}#g" \


### PR DESCRIPTION
Recently a change went in that validates the API token that is passed
as an argument against prod. But given that we use the shell install
script for testing against lab, we needed an option to pass non-prod
urls.
This change is to purely help internal use cases and testing.