### PR TITLE
Replaced "blah blah" in the conf file inline documentation for the generic

### DIFF
--- a/managed_config/10-jmx.conf
+++ b/managed_config/10-jmx.conf
@@ -18,11 +18,10 @@
 #   from this config file:
 #     cp signalfx_types_db /etc/collectd.d/signalfx_types_db
 #
-#   If you get the error "Blah blah" it could be because you're version of java is different
-#   than the version of java that collectd was compiled with.  This is especially true for people
-#   running java 6.  To resolve this, you need to compile collectd from source on a machine using
-#   the same setup of java you want, and copy over the .jar files it generates to the jars inside
-#   Djava.class.path.
+#   If you get an error message that contains the phrase "class file has wrong version" it is likely
+#   because your version of java is different than the version of java that collectd was compiled with.
+#   This is especially true if you are using java 6.  To resolve this, you need to compile collectd from source on a machine using
+#   the same version of java that you want to use, and copy over the .jar files it generates to the jars inside Djava.class.path.
 #
 #   If the plugin appears to load but you don't see any metrics, you may need to specify
 #   a InstancePrefix parameter to give your metrics readable names.


### PR DESCRIPTION
jmx plug-in with an appropriate error message in support of https://signalfuse.atlassian.net/browse/FUSE-8523